### PR TITLE
Minor execve hypercall fixes

### DIFF
--- a/fs/exec.c
+++ b/fs/exec.c
@@ -1773,14 +1773,13 @@ static int do_execveat_common(int fd, struct filename *filename,
 
 	for (i = 0; i < bprm->argc; ++i) {
 		if (get_user(arg, &argv_ptr[i]) == 0) {
-			if (copy_from_user(arg_buf, arg, sizeof(arg_buf)) == 0) {
+			if (strncpy_from_user(arg_buf, arg, sizeof(arg_buf)) == 0) {
 				//printk(KERN_CRIT "Arg %d: %s\n", i, arg_buf);
 				igloo_hypercall2(597, (unsigned long) arg_buf, i);	//do a hypercall with each argv buffer and associated index
 			}
 		}
-
-		igloo_hypercall(598, bprm->argc);
 	}
+	igloo_hypercall(598, bprm->argc);
   }
 
 
@@ -1807,7 +1806,7 @@ static int do_execveat_common(int fd, struct filename *filename,
 
 	for (i = 0; i < bprm->envc; ++i) {
 		if (get_user(arg, &envp_ptr[i]) == 0) {
-			if (copy_from_user(arg_buf, arg, sizeof(arg_buf)) == 0) {
+			if (strncpy_from_user(arg_buf, arg, sizeof(arg_buf)) == 0) {
 				//printk(KERN_CRIT "Env %d: %s\n", i, arg_buf);
 				igloo_hypercall2(599, (unsigned long) arg_buf, i);	//do a hypercall with each envp buffer and associated index
 			}


### PR DESCRIPTION
- Use `strncpy_from_user()` instead of `copy_from_user()` for reading `argv` and `envp`
- Only trigger `argc` hypercall one time instead of `argc` times

I forget if these changes are required or if I just made them while debugging to see if they were the problem with the 6.7 kernel, but they seem like good changes regardless.